### PR TITLE
Change github actions configuration and disable detekt

### DIFF
--- a/.github/workflows/static-analysis-checks.yml
+++ b/.github/workflows/static-analysis-checks.yml
@@ -4,9 +4,6 @@ on:
   pull_request:
     branches:
       - '**'
-  push:
-    branches:
-      - '**'
 
 jobs:
   test:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,7 +17,7 @@ subprojects {
     plugins.apply(BuildPlugins.ktlint)
 
     tasks.register("checkFormat") {
-        dependsOn("detekt", "ktlintCheck", "lintDebug", "spotlessCheck")
+        dependsOn("ktlintCheck", "lintDebug", "spotlessCheck")
     }
 
     tasks.register("reformat") {


### PR DESCRIPTION
Github workflow is disabled when local branch is pushed to origin. Detekt is disabled because its current configuration is not compatible with Compose.